### PR TITLE
Adding 95% low battery alert option

### DIFF
--- a/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -786,7 +786,7 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 }
                 alert.addAction(action)
 
-                for value in [20,30,40,50] {
+                for value in [20,30,40,50,95] {
                     let action = UIAlertAction.init(title: "\(value)%", style: .default) { _ in
                         self.batteryAlertLevel = value
                         self.tableView.reloadData()


### PR DESCRIPTION
NB: Please check carefully: this is my first PR ever ..

Reason for change: 
Lithium disposable batteries will stay at 100% capacity until ~the end. 
Adding a 95% battery alert will allow timely alerts. (50% means they have long died).