### PR TITLE
Add 95% battery alert option

### DIFF
--- a/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -786,7 +786,7 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 }
                 alert.addAction(action)
 
-                for value in [20,30,40,50] {
+                for value in [20,30,40,50,95] {
                     let action = UIAlertAction.init(title: "\(value)%", style: .default) { _ in
                         self.batteryAlertLevel = value
                         self.tableView.reloadData()


### PR DESCRIPTION
Adding options to alert at 95%, for batteries (like disposable lithium) that stay at ~100% until completely empty. 
(Please check: This is one of my first pull requests)