### PR TITLE
Fixes for suspend reminder handling when [auto] resuming pod

### DIFF
--- a/OmniKit/Model/AlertSlot.swift
+++ b/OmniKit/Model/AlertSlot.swift
@@ -364,3 +364,12 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
         }
     }
 }
+
+// Returns true if there are any active suspend related alerts
+public func hasActiveSuspendAlert(configuredAlerts: [AlertSlot : PodAlert]) -> Bool {
+    // slot5 is for podSuspendedReminder and slot6 is for suspendTimeExpired
+    if configuredAlerts.contains(where: { ($0.key == .slot5 || $0.key == .slot6) && $0.value.configuration.active }) {
+        return true
+    }
+    return false
+}

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1246,7 +1246,6 @@ extension OmnipodPumpManager: PumpManager {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
                 let beep = self.confirmationBeeps
                 let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
-                try session.cancelSuspendAlerts()
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
                 }
@@ -1367,7 +1366,6 @@ extension OmnipodPumpManager: PumpManager {
                     let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
                     let beep = self.confirmationBeeps
                     let podStatus = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
-                    try session.cancelSuspendAlerts()
                     guard podStatus.deliveryStatus.bolusing == false else {
                         throw SetBolusError.certain(PodCommsError.unfinalizedBolus)
                     }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -621,9 +621,9 @@ public class PodCommsSession {
         }
     }
 
-    // Cancels any suspend related alerts, should be called when resuming after using suspendDelivery()
+    // Cancels any suspend related alerts, called when setting a basal schedule with active suspend alerts
     @discardableResult
-    public func cancelSuspendAlerts() throws -> StatusResponse {
+    private func cancelSuspendAlerts() throws -> StatusResponse {
         do {
             let podSuspendedReminder = PodAlert.podSuspendedReminder(active: false, suspendTime: 0)
             let suspendTimeExpired = PodAlert.suspendTimeExpired(suspendTime: 0) // A suspendTime of 0 deactivates this alert
@@ -681,10 +681,15 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
 
         do {
-            let status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])
+            var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])
             let now = Date()
             podState.suspendState = .resumed(now)
             podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: now, scheduledCertainty: .certain)
+            if hasActiveSuspendAlert(configuredAlerts: podState.configuredAlerts),
+                let cancelStatus = try? cancelSuspendAlerts()
+            {
+                status = cancelStatus // update using the latest status
+            }
             podState.updateFromStatusResponse(status)
             return status
         } catch PodCommsError.nonceResyncFailed {


### PR DESCRIPTION
+ Properly handle status updates after cancelling suspend reminders
+ Have setBasalSchedule() call cancelSuspendAlerts() as needed
+ Active suspend alerts will now be cancelled for all auto resume cases
when suspended (manual bolus, Change Time Zone, Basal Rates edit)
+ Don't send alert commands when resuming with no active suspend alerts