### PR TITLE
Reworked shared basal rate support for Dash & Eros

### DIFF
--- a/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -164,7 +164,11 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public init(nonce: UInt32, basalSchedule: BasalSchedule, scheduleOffset: TimeInterval) {
         let scheduleOffsetNearestSecond = round(scheduleOffset)
         let table = BasalDeliveryTable(schedule: basalSchedule)
-        let rate = basalSchedule.rateAt(offset: scheduleOffsetNearestSecond)
+        var rate = roundToSupportedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
+        if rate == 0.0 {
+            // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
+            rate = nearZeroBasalRate
+        }
 
         let segment = Int(scheduleOffsetNearestSecond / BasalDeliveryTable.segmentDuration)
 

--- a/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniKit/MessageTransport/MessageBlocks/TempBasalExtraCommand.swift
@@ -14,7 +14,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public let completionBeep: Bool
     public let programReminderInterval: TimeInterval
     public let remainingPulses: Double
-    public let delayUntilFirstTenthOfPulse: TimeInterval
+    public let delayUntilFirstPulse: TimeInterval
     public let rateEntries: [RateEntry]
 
     public let blockType: MessageBlockType = .tempBasalExtra
@@ -27,12 +27,8 @@ public struct TempBasalExtraCommand : MessageBlock {
             beepOptions,
             0
             ])
-        data.appendBigEndian(UInt16(round(remainingPulses * 2) * 5))
-        if remainingPulses == 0 {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds) * 10)
-        } else {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds))
-        }
+        data.appendBigEndian(UInt16(round(remainingPulses * 10)))
+        data.appendBigEndian(UInt32(delayUntilFirstPulse.hundredthsOfMilliseconds))
         for entry in rateEntries {
             data.append(entry.data)
         }
@@ -40,6 +36,9 @@ public struct TempBasalExtraCommand : MessageBlock {
     }
 
     public init(encodedData: Data) throws {
+        if encodedData.count < 14 {
+            throw MessageBlockError.notEnoughData
+        }
         
         let length = encodedData[1]
         let numEntries = (length - 8) / 6
@@ -50,22 +49,14 @@ public struct TempBasalExtraCommand : MessageBlock {
         
         remainingPulses = Double(encodedData[4...].toBigEndian(UInt16.self)) / 10.0
         let timerCounter = encodedData[6...].toBigEndian(UInt32.self)
-        if remainingPulses == 0 {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter) / 10)
-        } else {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-        }
+        delayUntilFirstPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
+
         var entries = [RateEntry]()
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self)
-            let delayBetweenPulses: TimeInterval
-            if totalPulses == 0 {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter)) / 10
-            } else {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-            }
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~nearZeroBasalRateFlag
+            let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
         rateEntries = entries
@@ -74,7 +65,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public init(rate: Double, duration: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
         rateEntries = RateEntry.makeEntries(rate: rate, duration: duration)
         remainingPulses = rateEntries[0].totalPulses
-        delayUntilFirstTenthOfPulse = rateEntries[0].delayBetweenPulses
+        delayUntilFirstPulse = rateEntries[0].delayBetweenPulses
         self.acknowledgementBeep = acknowledgementBeep
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval
@@ -83,6 +74,6 @@ public struct TempBasalExtraCommand : MessageBlock {
 
 extension TempBasalExtraCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilNextPulse:\(delayUntilFirstTenthOfPulse.stringValue), rateEntries:\(rateEntries))"
+        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilFirstPulse:\(delayUntilFirstPulse.stringValue), rateEntries:\(rateEntries))"
     }
 }

--- a/OmniKit/Model/BasalSchedule.swift
+++ b/OmniKit/Model/BasalSchedule.swift
@@ -16,7 +16,12 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = rate
+        var rrate = roundToSupportedBasalRate(rate: rate)
+        if rrate == 0 && Pod.zeroBasalRate == 0 {
+            // Got a zero scheduled basal rate for an Eros pod, use the min allowed
+            rrate = Pod.pulseSize
+        }
+        self.rate = rrate
         self.startTime = startTime
     }
     

--- a/OmniKit/Model/Pod.swift
+++ b/OmniKit/Model/Pod.swift
@@ -53,7 +53,13 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
+    // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
+    // Would need to have this value based on productID to be able to share this with Eros.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
+
+    // The internal basal rate used for non-Eros pods
+    // Would need to have this value based on productID to be able to share this file with Eros.
+    public static let zeroBasalRate: Double = 0.0
 
     // Maximum number of basal schedule entries supported
     public static let maximumBasalScheduleEntryCount: Int = 24

--- a/OmniKitTests/TempBasalTests.swift
+++ b/OmniKitTests/TempBasalTests.swift
@@ -164,11 +164,11 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 1800), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
             XCTAssertEqual(0, cmd.remainingPulses)
             XCTAssertEqual(1, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
-            XCTAssertEqual(TimeInterval(seconds: 1800), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
             XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
             XCTAssertEqual(0, entry.rate)
             
@@ -188,14 +188,14 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 1800), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
             XCTAssertEqual(0, cmd.remainingPulses)
             XCTAssertEqual(6, cmd.rateEntries.count)
-            let entry = cmd.rateEntries[0]
-            XCTAssertEqual(TimeInterval(seconds: 1800), entry.delayBetweenPulses)
-            XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
-            XCTAssertEqual(0, entry.rate)
-            
+            for entry in cmd.rateEntries {
+                XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+                XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+                XCTAssertEqual(0, entry.rate)
+            }
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
@@ -205,6 +205,33 @@ class TempBasalTests: XCTestCase {
         XCTAssertEqual("162c7c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200", cmd.data.hexadecimalString)
     }
 
+    func testZeroTempTwelveHoursExtraCommand() {
+        do {
+            // 0 U/h for 12 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+            //        16 98 7c 00 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200 0000 6b49d200
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "16987c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(0, cmd.remainingPulses)
+            XCTAssertEqual(24, cmd.rateEntries.count)
+            for entry in cmd.rateEntries {
+                XCTAssertEqual(0, entry.totalPulses)
+                XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+                XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+                XCTAssertEqual(0, entry.rate)
+            }
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 0, duration: .hours(12), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("16987c0000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d20000006b49d200", cmd.data.hexadecimalString)
+    }
 
     func testTempBasalExtremeValues() {
         do {
@@ -244,7 +271,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(true, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
             XCTAssertEqual(300, cmd.remainingPulses)
             XCTAssertEqual(1, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
@@ -292,7 +319,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(false, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
             XCTAssertEqual(6300, cmd.remainingPulses)
             XCTAssertEqual(2, cmd.rateEntries.count)
             let entry = cmd.rateEntries[0]
@@ -316,7 +343,7 @@ class TempBasalTests: XCTestCase {
             XCTAssertEqual(false, cmd.acknowledgementBeep)
             XCTAssertEqual(false, cmd.completionBeep)
             XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
-            XCTAssertEqual(TimeInterval(seconds: 6.01001), cmd.delayUntilFirstTenthOfPulse)
+            XCTAssertEqual(TimeInterval(seconds: 6.01001), cmd.delayUntilFirstPulse)
             XCTAssertEqual(6289.5, cmd.remainingPulses)
             XCTAssertEqual(2, cmd.rateEntries.count)
             let entry1 = cmd.rateEntries[0]


### PR DESCRIPTION
* Reworked shared basal rate support for Dash & Eros
+ Dash zero scheduled basal rates now supported
+ Dash zero temp basal corrected for all durations
+ Eros zero temp basal rate clean up work
+ Handle any non-standard basal rates
+ Add new unit test for non-standrad basal rates
+ Add new tests for Dash zero basal rate schedules
+ Add new tests for Dash style zero temp basal
+ Add missing tests from OmniKitTests
+ Fix to handle an imported zero basal schedule rate on Eros
+ Add new unit test for sample MDT 723 only basal schedule import