### PR TITLE
Backport name changes and improvements from iAPS integration

### DIFF
--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -30,9 +30,6 @@ public struct Pod {
     // Units per second for priming/cannula insertion
     public static let primeDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerPrimePulse
 
-    // User configured time before expiration advisory (PDM allows 1-24 hours)
-    public static let expirationAlertWindow = TimeInterval(hours: 2)
-
     // Expiration advisory window: time after expiration alert, and end of service imminent alarm
     public static let expirationAdvisoryWindow = TimeInterval(hours: 7)
 
@@ -81,9 +78,18 @@ public struct Pod {
     public static let cannulaInsertionUnitsExtra = 0.0 // edit to add a fixed additional amount of insulin during cannula insertion
 
     // Default and limits for expiration reminder alerts
-    public static let expirationReminderAlertDefaultTimeBeforeExpiration = TimeInterval.hours(2)
+    public static let defaultExpirationReminderOffset = TimeInterval(hours: 2)
     public static let expirationReminderAlertMinTimeBeforeExpiration = TimeInterval.hours(1)
     public static let expirationReminderAlertMaxTimeBeforeExpiration = TimeInterval.hours(24)
+
+    // Threshold used to display pod end of life warnings
+    public static let timeRemainingWarningThreshold = TimeInterval(days: 1)
+
+    // Default low reservoir alert limit in Units
+    public static let defaultLowReservoirReminder: Double = 10
+
+    // Allowed Low Reservoir reminder values
+    public static let allowedLowReservoirReminderValues = Array(stride(from: 10, through: 50, by: 1))
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus

--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -128,7 +128,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
         if let expirationReminderDate = rawValue["expirationReminderDate"] as? Date {
             self.expirationReminderDate = expirationReminderDate
         } else if let expiresAt = podState?.expiresAt {
-            self.expirationReminderDate = expiresAt.addingTimeInterval(-Pod.expirationReminderAlertDefaultTimeBeforeExpiration)
+            self.expirationReminderDate = expiresAt.addingTimeInterval(-Pod.defaultExpirationReminderOffset)
         }
 
         if let rawUnstoredDoses = rawValue["unstoredDoses"] as? [UnfinalizedDose.RawValue] {
@@ -210,8 +210,8 @@ extension OmnipodPumpManagerState: CustomDebugStringConvertible {
             "* pairingAttemptAddress: \(String(describing: pairingAttemptAddress))",
             "* rileyLinkBatteryAlertLevel: \(String(describing: rileyLinkBatteryAlertLevel))",
             "* lastRileyLinkBatteryAlertDate \(String(describing: lastRileyLinkBatteryAlertDate))",
-            String(reflecting: podState),
-            String(reflecting: rileyLinkConnectionManagerState),
+            "* RileyLinkConnectionManagerState: " + (rileyLinkConnectionManagerState == nil ? "nil\n" : String(describing: rileyLinkConnectionManagerState!)),
+            "* PodState: " + (podState == nil ? "nil\n" : String(describing: podState!)),
         ].joined(separator: "\n")
     }
 }

--- a/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
+++ b/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
@@ -157,7 +157,7 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
                 lifetime = 0
             }
             rawValue["lifetime"] = lifetime
-            rawValue["alerts"] = alertString(alerts: podState.activeAlertSlots)
+            rawValue["alerts"] = alertSetString(alertSet: podState.activeAlertSlots)
         }
         
         if let lastInsulinMeasurements = podState?.lastInsulinMeasurements {

--- a/OmniKitUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniKitUI/ViewControllers/CommandResponseViewController.swift
@@ -71,7 +71,7 @@ extension CommandResponseViewController {
 
         result += String(format: LocalizedString("Reservoir Level: %1$@ U\n", comment: "The format string for Reservoir Level: (1: reservoir level string)"), status.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : status.reservoirLevel.twoDecimals)
 
-        result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertString(alerts: status.unacknowledgedAlerts))
+        result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertSetString(alertSet: status.unacknowledgedAlerts))
 
         if status.radioRSSI != 0 {
             result += String(format: LocalizedString("RSSI: %1$@\n", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))

--- a/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniKitUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -404,7 +404,7 @@ class OmnipodSettingsViewController: RileyLinkSettingsViewController {
             case .podActive:
                 let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
                 cell.textLabel?.text = LocalizedString("Pod Active", comment: "The title of the cell showing pod active time")
-                cell.setDetailAge(self.pumpManager.timeActive)
+                cell.setDetailAge(self.pumpManager.podTime)
                 return cell
             case .bolus:
                 cell.textLabel?.text = LocalizedString("Bolus Delivery", comment: "The title of the cell showing pod bolus status")
@@ -1010,7 +1010,7 @@ class AlarmsTableViewCell: LoadingTableViewCell {
             if alerts.isEmpty {
                 detailTextLabel?.text = LocalizedString("None", comment: "Alerts detail when no alerts unacknowledged")
             } else {
-                detailTextLabel?.text = alertString(alerts: alerts)
+                detailTextLabel?.text = alertSetString(alertSet: alerts)
             }
         }
     }


### PR DESCRIPTION
+ Rename podState timeActive -> podTime for better clarity
+ Rename alertString() -> alertSetString() for clarity & consistency
+ New configuredAlertString() that displays trigger information
+ Improved podState debugDescription formatting
+ Acknowledge all alerts when reseting flipping silence pod state
+ Use 15 minute reminders when changing silence pod after suspend time expired
+ CreatePodAlerts() generalized and named regeneratePodAlerts()
+ Make lowReservoir alert inactive if pod reservoir level is below limit